### PR TITLE
Auto fill invoice

### DIFF
--- a/src/atom/clientsAtom.tsx
+++ b/src/atom/clientsAtom.tsx
@@ -1,0 +1,3 @@
+import { atom } from "jotai";
+
+export const clientsAtom = atom<TClientBack[]>([]);

--- a/src/atom/societyAtom.tsx
+++ b/src/atom/societyAtom.tsx
@@ -2,15 +2,13 @@ import { atom } from "jotai";
 import Cookies from "js-cookie";
 
 export const currentSocietyAtom = atom(
-  Cookies.get("currentSociety")
-    ? JSON.parse(Cookies.get("currentSociety")!)
-    : null
+  Cookies.get("currentSociety") ? JSON.parse(Cookies.get("currentSociety")!) : null
 );
 
 const societyAtom = atom({
   id: "",
   name: "",
-  adress: "",
+  address: "",
   zip: "",
   city: "",
   country: "",
@@ -19,5 +17,7 @@ const societyAtom = atom({
   capital: "",
   email: "",
 });
+
+export const societiesAtom = atom<TSocietyBack[]>([]);
 
 export default societyAtom;

--- a/src/components/clients/ClientEdit.tsx
+++ b/src/components/clients/ClientEdit.tsx
@@ -25,7 +25,7 @@ const ClientEdit = ({
     setValue("business_name", clientData.business_name!);
     setValue("first_name", clientData.first_name!);
     setValue("last_name", clientData.last_name!);
-    setValue("siret", clientData.siret!);
+    setValue("siret", clientData.siret!.toString());
     setValue("address", clientData.address);
     setValue("zip", clientData.zip);
     setValue("city", clientData.city);
@@ -44,10 +44,7 @@ const ClientEdit = ({
   const onSubmit = async (data: FormValues) => {
     const formData = new FormData();
 
-    formData.append(
-      "client[user_id]",
-      JSON.parse(Cookies.get("token")!).user_id
-    );
+    formData.append("client[user_id]", JSON.parse(Cookies.get("token")!).user_id);
     formData.append("client[society_id]", String(1)); // !! TO CHANGE !!
     formData.append("client[business_name]", data.business_name!);
     formData.append("client[first_name]", data.first_name!);
@@ -59,12 +56,7 @@ const ClientEdit = ({
     formData.append("client[is_pro]", String(data.siret ? true : false));
 
     try {
-      const response = await fetcher(
-        `/clients/${clientData.id}`,
-        formData,
-        "PUT",
-        true
-      );
+      const response = await fetcher(`/clients/${clientData.id}`, formData, "PUT", true);
       if (!response.error) {
         console.log("Client updated successfully");
         setClientData(response);
@@ -160,11 +152,7 @@ const ClientEdit = ({
           </div>
         </div>
 
-        <input
-          type="submit"
-          value="Save changes"
-          className="btn client-form__submit"
-        />
+        <input type="submit" value="Save changes" className="btn client-form__submit" />
       </form>
     </>
   );

--- a/src/components/invoice/Invoice.tsx
+++ b/src/components/invoice/Invoice.tsx
@@ -328,13 +328,13 @@ export default function Invoice({
     }
   }, [clients.length, currentSociety, setClients]);
 
-  useEffect(() => {
-    console.log("clients", clients);
-  }, [clients]);
+  // useEffect(() => {
+  //   console.log("clients", clients);
+  // }, [clients]);
 
-  useEffect(() => {
-    console.log("client", client);
-  }, [client]);
+  // useEffect(() => {
+  //   console.log("client", client);
+  // }, [client]);
 
   const handleClientSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const clientId = event.target.value;

--- a/src/components/invoice/Invoice.tsx
+++ b/src/components/invoice/Invoice.tsx
@@ -8,6 +8,7 @@ import { successAtom } from "../../atom/notificationAtom";
 import { clientsAtom } from "../../atom/clientsAtom";
 import { currentSocietyAtom, societiesAtom } from "../../atom/societyAtom";
 import societyAtom from "../../atom/societyAtom";
+import Switch from "react-switch";
 
 export default function Invoice({
   authorProp,
@@ -237,6 +238,13 @@ export default function Invoice({
           is_valid: true,
         };
       });
+    } else {
+      setInvoice((prevInvoice) => {
+        return {
+          ...prevInvoice,
+          is_valid: false,
+        };
+      });
     }
   }, [client, author, setInvoice]);
 
@@ -281,10 +289,10 @@ export default function Invoice({
   // Auto save after 5s
   const [autoSave, setAutoSave] = useState<null | NodeJS.Timeout>(null);
   const triggerAutoSave = () => {
-    if (!invoice.is_valid) return;
     if (autoSave) {
       clearTimeout(autoSave);
     }
+    if (!invoice.is_valid) return;
 
     const timeout = setTimeout(() => {
       handleSave();
@@ -340,12 +348,13 @@ export default function Invoice({
             street: "",
             zip: "",
             city: "",
-            country: "FR",
+            country: "",
           },
           siret: undefined,
           is_pro: false,
           name: "",
           surname: "",
+          email: "",
         } as TUserInfos;
       });
       return;
@@ -464,6 +473,15 @@ export default function Invoice({
               </option>
             ))}
         </select>
+        <div>
+          Client pro ?
+          <Switch
+            checked={client.is_pro!}
+            onChange={() =>
+              setClient((prevClient) => ({ ...prevClient, is_pro: !prevClient.is_pro }))
+            }
+          />
+        </div>
         <UserInfos user={client} setUser={setClient} />
       </div>
       <div className="invoice__title">

--- a/src/components/invoice/Invoice.tsx
+++ b/src/components/invoice/Invoice.tsx
@@ -9,6 +9,7 @@ import { clientsAtom } from "../../atom/clientsAtom";
 import { currentSocietyAtom, societiesAtom } from "../../atom/societyAtom";
 import societyAtom from "../../atom/societyAtom";
 import Switch from "react-switch";
+import { useNavigate } from "react-router-dom";
 
 export default function Invoice({
   authorProp,
@@ -21,6 +22,7 @@ export default function Invoice({
 }) {
   const setSuccess = useSetAtom(successAtom);
   const [society, setSociety] = useAtom(societyAtom);
+  const navigate = useNavigate();
   const [author, setAuthor] = useState(
     authorProp ||
       ({
@@ -283,7 +285,11 @@ export default function Invoice({
           };
         });
       }
+
+      return Promise.resolve();
     }
+
+    return Promise.reject();
   };
 
   // Auto save after 5s
@@ -600,7 +606,9 @@ export default function Invoice({
           </tfoot>
         </table>
       </div>
-      <button onClick={handleSave} disabled={!invoice.is_valid}>
+      <button
+        onClick={() => handleSave().then(() => navigate(`/invoices/${invoice.id}`))}
+        disabled={!invoice.is_valid}>
         Enregistrer la facture
       </button>
     </div>

--- a/src/pages/invoices/EditInvoice.tsx
+++ b/src/pages/invoices/EditInvoice.tsx
@@ -8,7 +8,7 @@ const EditInvoice = () => {
   const { id } = useParams();
   const [invoiceData, setInvoiceData] = useState<TInvoice>();
   const [author, setAuthor] = useState<TUserInfos>();
-  // const [client, setClient] = useState<TUserInfos>();
+  const [client, setClient] = useState<TUserInfos>();
 
   useEffect(() => {
     const fetchInvoice = async () => {
@@ -19,7 +19,7 @@ const EditInvoice = () => {
           const invoice = invoiceDataFormatterReceive(response);
           setInvoiceData(invoice);
           setAuthor(invoice.author);
-          // setClient(invoice.client);
+          setClient(invoice.client);
         } else {
           console.error(response.error);
         }
@@ -35,8 +35,10 @@ const EditInvoice = () => {
       <h1>EditInvoice</h1>
       <Link to={`/invoices/${id}`}>Back to invoice #{id}</Link>
       {!invoiceData && <p>Loading...</p>}
-      {invoiceData && author && <Invoice invoiceProp={invoiceData} authorProp={author} />}
-      {/* {invoiceData && author && client && <Invoice invoiceProp={invoiceData} authorProp={author} clientProp={client} />} */}
+      {/* {invoiceData && author && <Invoice invoiceProp={invoiceData} authorProp={author} />} */}
+      {invoiceData && author && client && (
+        <Invoice invoiceProp={invoiceData} authorProp={author} clientProp={client} />
+      )}
     </>
   );
 };

--- a/src/pages/invoices/ShowInvoice.tsx
+++ b/src/pages/invoices/ShowInvoice.tsx
@@ -110,6 +110,27 @@ const ShowInvoice = () => {
   return (
     <>
       <h1>Invoice {invoiceData?.number}</h1>
+      <Link to="/invoices">&#8592; Back to invoices list</Link>
+      <div
+        style={{
+          display: "flex",
+          gap: 10,
+          justifyContent: "space-around",
+          marginTop: 20,
+          marginBottom: 10,
+          alignItems: "center",
+        }}>
+        <Link to={`/invoices/${id}/edit`} className="btn">
+          Edit
+        </Link>
+        <button
+          className="btn btn-red"
+          onClick={() => {
+            window.confirm("Are you sure to delete this invoice?") && onClick();
+          }}>
+          Delete
+        </button>
+      </div>
       {invoiceData && (
         <>
           <div>
@@ -134,9 +155,6 @@ const ShowInvoice = () => {
           </div>
         </>
       )}
-      <Link to="/invoices">Back to invoices list</Link>
-      <Link to={`/invoices/${id}/edit`}>Edit</Link>
-      <button onClick={onClick}>Delete</button>
     </>
   );
 };

--- a/src/types/client.d.ts
+++ b/src/types/client.d.ts
@@ -10,3 +10,21 @@ type TClient = {
   is_pro: boolean;
   siret?: string;
 };
+
+type TClientBack = {
+  id: number;
+  first_name: string;
+  last_name: string;
+  business_name: string;
+  email: string;
+  address: string;
+  zip: number;
+  city: string;
+  country: string;
+  siret: number;
+  is_pro: boolean;
+  user_id: number;
+  society_id: number;
+  created_at: string;
+  updated_at: string;
+};

--- a/src/types/invoice.d.ts
+++ b/src/types/invoice.d.ts
@@ -34,6 +34,7 @@ type TInvoice = {
   is_paid?: boolean;
   status?: string;
   additionalInfo?: string;
+  is_valid?: boolean;
 };
 
 type TItem = {

--- a/src/types/society.d.ts
+++ b/src/types/society.d.ts
@@ -1,6 +1,6 @@
 type TSocietyBack = {
   id: number;
-  adress: string;
+  address: string;
   city: string;
   zip: number;
   country: string;

--- a/src/utils/invoiceDataFormatter.tsx
+++ b/src/utils/invoiceDataFormatter.tsx
@@ -79,7 +79,9 @@ const invoiceDataFormatterReceive = (invoice: TInvoiceShowBack) => {
       street: author.address,
       city: author.city,
       zip: author.zip.toString(),
+      country: author.country,
     },
+    siret: author.siret,
   } as TUserInfos;
 
   const client = invoice.client;
@@ -93,6 +95,7 @@ const invoiceDataFormatterReceive = (invoice: TInvoiceShowBack) => {
       street: client.address,
       city: client.city,
       zip: client.zip.toString(),
+      country: client.country,
     },
   } as TUserInfos;
 

--- a/src/utils/invoiceDataFormatter.tsx
+++ b/src/utils/invoiceDataFormatter.tsx
@@ -47,6 +47,8 @@ const invoiceDataFormatterSend = (invoice: TInvoice) => {
     formData.append("invoice[client_infos][address]", invoice.client.address.street);
     formData.append("invoice[client_infos][city]", invoice.client.address.city);
     formData.append("invoice[client_infos][zip]", invoice.client.address.zip);
+    formData.append("invoice[client_infos][country]", invoice.client.address.country);
+    formData.append("invoice[client_infos][email]", invoice.client.email || "");
   }
 
   if (invoice.author.id && invoice.author.modified) {
@@ -74,7 +76,7 @@ const invoiceDataFormatterReceive = (invoice: TInvoiceShowBack) => {
     email: author.email,
     is_pro: true,
     address: {
-      street: author.adress,
+      street: author.address,
       city: author.city,
       zip: author.zip.toString(),
     },


### PR DESCRIPTION
Avant toute chose : bon courage pour la review.

Changes :
- New Atom : `societies` representing the list of all societies owned by the connected user
- Auto fill the invoice with a select representing the `user's societies` and the `societies' clients` (or `user's clients` if no society is selected)
- Added a switch for the client to determine if the client is a pro or not
- Added validation to auto-save and save button (need at least a society, and client to generate the invoice)
- On click on save button -> navigate to show invoice
- On show Invoice, moved buttons to easy access and added new infos to clients and society 
- The clients now can have an email address and a country